### PR TITLE
Add use-focus-outside hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,40 @@ SOON...
 
 ---
 
+### `useFocusOutside` - [View code](https://github.com/stevenpersia/captain-hook/blob/master/useFocusOutside.js)
+
+Useful hook if you want some element to close or hide when it lost focus 
+from the user.
+
+#### How to use
+
+Import hook :
+
+```js
+import { useFocusOutside } from "hooks/useFocusOutside";
+```
+
+Then use like this :
+
+```js
+const ref = useRef(null);
+
+const closeOrHide = () => {
+  // some code to close or hide your element.
+}
+
+useFocusOutside(ref, closeOrHide);
+```
+
+> Note: you need to pass **ref** into the element that should be focussed 
+outside of.
+
+#### Demo
+
+SOON...
+
+---
+
 ## Star, Fork, Clone & Contribute
 
 Feel free to contribute on this repository. If my work helps you, please give me back with a star. This means a lot to me and keeps me going!

--- a/useFocusOutside.js
+++ b/useFocusOutside.js
@@ -1,0 +1,48 @@
+/**
+ * useFocusOutside
+ *
+ * Watch for events outside of current element and invoke the
+ * callback function when triggered.
+ *
+ * @param outerRef Reference to the element to focus outside of
+ * @param callback Function to call when focus is outside
+ */
+import usePassiveEventListener from './usePassiveEventListener'
+
+const useFocusOutside = (outerRef, callback) => {
+  const clickedOrTabbedOutside = e => {
+    // Pressing any other key than these does nothing
+    // 9 = tab, 27 = esc
+    if (e.type === 'keyup' && [9, 27].indexOf(e.keyCode) === -1) {
+      return
+    }
+
+    // Esc key immediately calls callback
+    if (e.type === 'keyup' && [27].indexOf(e.keyCode) !== -1) {
+      callback()
+
+      return
+    }
+
+    // If target element is inside the component, focus is not outside
+    if (e.target instanceof Node && outerRef.current.contains(e.target)) {
+      return
+    }
+
+    // For blur, only trigger on Window events
+    if (e.type === 'blur' && !(e.target instanceof Window)) {
+      return
+    }
+
+    // Call user defined callback
+    callback()
+  }
+
+  // Register and deregister events globally
+  usePassiveEventListener('contextmenu', clickedOrTabbedOutside)
+  usePassiveEventListener('click', clickedOrTabbedOutside)
+  usePassiveEventListener('keyup', clickedOrTabbedOutside)
+  usePassiveEventListener('blur', clickedOrTabbedOutside)
+}
+
+export default useFocusOutside;


### PR DESCRIPTION
This will add the useFocusOutside hook.

It will help finding out when the focus from a certain element is lost.

This PR relies on #6 , which should be merged before this.